### PR TITLE
never turn booleans into arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,25 @@ module.exports = function (args, opts) {
             setKey(argv, x.split('.'), value);
         });
     }
+
+    function setKey (obj, keys, value) {
+        var o = obj;
+        keys.slice(0,-1).forEach(function (key) {
+            if (o[key] === undefined) o[key] = {};
+            o = o[key];
+        });
+
+        var key = keys[keys.length - 1];
+        if (o[key] === undefined || flags.bools[key]) {
+            o[key] = value;
+        }
+        else if (Array.isArray(o[key])) {
+            o[key].push(value);
+        }
+        else {
+            o[key] = [ o[key], value ];
+        }
+    }
     
     for (var i = 0; i < args.length; i++) {
         var arg = args[i];
@@ -190,25 +209,6 @@ function hasKey (obj, keys) {
 
     var key = keys[keys.length - 1];
     return key in o;
-}
-
-function setKey (obj, keys, value) {
-    var o = obj;
-    keys.slice(0,-1).forEach(function (key) {
-        if (o[key] === undefined) o[key] = {};
-        o = o[key];
-    });
-    
-    var key = keys[keys.length - 1];
-    if (o[key] === undefined || typeof o[key] === 'boolean') {
-        o[key] = value;
-    }
-    else if (Array.isArray(o[key])) {
-        o[key].push(value);
-    }
-    else {
-        o[key] = [ o[key], value ];
-    }
 }
 
 function isNumber (x) {

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ module.exports = function (args, opts) {
         });
 
         var key = keys[keys.length - 1];
-        if (o[key] === undefined || flags.bools[key]) {
+        if (o[key] === undefined || flags.bools[key] || typeof o[key] === 'boolean') {
             o[key] = value;
         }
         else if (Array.isArray(o[key])) {

--- a/test/default_bool.js
+++ b/test/default_bool.js
@@ -18,3 +18,18 @@ test('boolean default false', function (t) {
     t.equal(argv.somefalse, false);
     t.end();
 });
+
+test('boolean default to null', function (t) {
+    var argv = parse([], {
+        boolean: 'maybe',
+        default: { maybe: null }
+    });
+    t.equal(argv.maybe, null);
+    var argv = parse(['--maybe'], {
+        boolean: 'maybe',
+        default: { maybe: null }
+    });
+    t.equal(argv.maybe, true);
+    t.end();
+
+})


### PR DESCRIPTION
fixes issue https://github.com/substack/minimist/issues/44

I had to move setKey to where it had access to flags, but otherwise just changed check that current value was a boolean, into a check that the type for that field should be boolean.

Unless you are creating a boolean and setting the default type to a non boolean (i.e. null) this change is backward compatible.