### PR TITLE
Update npm before running tests on travis for Node 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+before_install:
+  - npm install -g npm@~1.4.6


### PR DESCRIPTION
Hi!

Travis has been falling for Node 0.8 with old npm version (see https://github.com/npm/npm/issues/4849).

This patch fixes breakage tests.
