### PR TITLE
reordered options list so the example is closer

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -63,11 +63,11 @@ argument names to use as aliases
 * `opts.default` - an object mapping string argument names to default values
 * `opts.stopEarly` - when true, populate `argv._` with everything after the
 first non-option
-* `opts['--']` - when true, populate `argv._` with everything before the `--`
-and `argv['--']` with everything after the `--`. Here's an example:
 * `opts.unknown` - a function which is invoked with a command line parameter not
 defined in the `opts` configuration object. If the function returns `false`, the
 unknown option is not added to `argv`.
+* `opts['--']` - when true, populate `argv._` with everything before the `--`
+and `argv['--']` with everything after the `--`. Here's an example:
 
 ```
 > require('./')('one two three -- four five --six'.split(' '), { '--': true })


### PR DESCRIPTION
Reordered an option in the options list so that it was closer to its example.

Was:
- blah blah. Here's an example:
- blah blah blah blah  
`EXAMPLE`

Now:
- blah blah blah blah
- blah blah. Here's an example:  
`EXAMPLE`