### PR TITLE
Increment bools when passed multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 module.exports = function (args, opts) {
     if (!opts) opts = {};
     
+    // Ascertain which `minimist`-options have been passed, reading `flags`,
+    // `aliases`, and `defaults`;
     var flags = { bools : {}, strings : {}, unknownFn: null };
     var everyBool = {};
 
@@ -48,6 +50,7 @@ module.exports = function (args, opts) {
         args = args.slice(0, args.indexOf('--'));
     }
 
+    // Create a few helper-functions that break up the parsing process;
     function argDefined(key, arg) {
         return (flags.allBools && /^--[^=]+$/.test(arg)) ||
             flags.strings[key] || flags.bools[key] || aliases[key];
@@ -110,6 +113,7 @@ module.exports = function (args, opts) {
         }
     }
     
+    // Actually parse the arguments!
     for (var i = 0; i < args.length; i++) {
         var arg = args[i];
         
@@ -201,6 +205,7 @@ module.exports = function (args, opts) {
         }
     }
     
+    // And set the default values for any omitted args.
     Object.keys(defaults).forEach(function (key) {
         if (!hasKey(argv, key.split('.'))) {
             setKey(argv, key.split('.'), defaults[key]);

--- a/index.js
+++ b/index.js
@@ -64,14 +64,16 @@ module.exports = function (args, opts) {
         var value = !flags.strings[key] && isNumber(val)
             ? Number(val) : val
         ;
-        setKey(argv, key.split('.'), value);
+        setKey(argv, key, value);
         
-        (aliases[key] || []).forEach(function (x) {
-            setKey(argv, x.split('.'), value);
+        (aliases[key] || []).forEach(function (alias) {
+            setKey(argv, alias, value);
         });
     }
 
-    function setKey (obj, keys, value) {
+    function setKey (obj, fullKey, value) {
+        var keys = fullKey.split('.');
+
         var o = obj;
         keys.slice(0,-1).forEach(function (key) {
             if (o[key] === undefined) o[key] = {};
@@ -207,11 +209,11 @@ module.exports = function (args, opts) {
     
     // And set the default values for any omitted args.
     Object.keys(defaults).forEach(function (key) {
-        if (!hasKey(argv, key.split('.'))) {
-            setKey(argv, key.split('.'), defaults[key]);
+        if (!hasKey(argv, key)) {
+            setKey(argv, key, defaults[key]);
             
             (aliases[key] || []).forEach(function (x) {
-                setKey(argv, x.split('.'), defaults[key]);
+                setKey(argv, x, defaults[key]);
             });
         }
     });
@@ -231,7 +233,9 @@ module.exports = function (args, opts) {
     return argv;
 };
 
-function hasKey (obj, keys) {
+function hasKey (obj, fullKey) {
+    var keys = fullKey.split('.');
+
     var o = obj;
     keys.slice(0,-1).forEach(function (key) {
         o = (o[key] || {});

--- a/test/multi_bool.js
+++ b/test/multi_bool.js
@@ -1,0 +1,73 @@
+var parse = require('../');
+var test = require('tape');
+
+test('incrementing multi-booleans', function (t) {
+    var argv = parse(['-VVV', '--verbose', '--verbose']);
+    t.same(argv, {
+        V: 3,
+        verbose: 2,
+        _: []
+    });
+    t.end();
+});
+
+test('multi-boolean with an alias', function (t) {
+    var argv = parse(['-VV', '--verbose', '--verbose'], {
+        alias: { 'V': 'verbose' },
+        boolean: 'V'
+    });
+    t.same(argv, {
+        V: 4,
+        verbose: 4,
+        _: []
+    });
+    t.end();
+});
+
+test('incremented multi-booleans revert to individual booleans when interleaved',
+        function (t) {
+
+    var argv = parse(['--verb', '--verb']);
+    t.same(argv, { verb: 2, _: [] });
+
+    var argv = parse(['--verb', '--verb', '--verb=abc']);
+    t.same(argv, { verb: [true, true, 'abc'], _: [] });
+
+    var argv = parse(['--verb', '--verb', '--verb=abc', '--verb']);
+    t.same(argv, { verb: [true, true, 'abc', true], _: [] });
+
+    var argv = parse(['-VV']);
+    t.same(argv, { V: 2, _: [] });
+
+    var argv = parse(['-VVV', 'abc']);
+    t.same(argv, { V: [true, true, 'abc'], _: [] });
+
+
+    t.end();
+});
+
+test('multi-boolean negation', function (t) {
+    var argv = parse(['--verbose', '--verbose', '--no-verbose']);
+    t.same(argv, {
+        verbose: false,
+        _: []
+    });
+
+    var argv = parse(['--verbose', '--verbose', '--no-verbose', '--verbose']);
+    t.same(argv, {
+        verbose: true,
+        _: []
+    });
+
+    var argv = parse(['-VVV', '--no-verbose', '-VV'], {
+        alias: { 'V': 'verbose' },
+        boolean: 'V'
+    });
+    t.same(argv, {
+        V: 2,
+        verbose: 2,
+        _: []
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Now, when passed `-VVV` or `--foo --foo --foo`, the implementer will receive `{ V: 3 }` or similar instead of simply `{ V: true }`. This shouldn't break the API for *the vast majority* of users; as positive integers are

Notes on my implementation herein:

 - If *non*-boolean values for a given flag are passed, and it isn't explicitly set as a boolean flag, then this behaviour is thrown out, and the previous ‘stacking value’ behaviour is retained (`--foo --foo --foo=3` becomes `{ foo: [true, true, 3] }` instead of trying to intuit some combination of incremented-boolean and numeric.) If the user doesn't want to deal with arrays with multiple types of values, then they simply do what they'd already need to do: set that key specifically as boolean in the `opts`.
 - If it is ever negated, the count is reset to 0; and it's turned into a boolean again (that is, a `--no-verbose` later on trumps the preceding `-VVV`, so to speak.)

There's some clean-up commits here as well; but they're contained separately. Feel free to cherry-pick only the meaty commit if you prefer.