### PR TITLE
Convert boolean arguments to boolean values

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,12 @@ module.exports = function (args, opts) {
             // 'dotall' regex modifier. See:
             // http://stackoverflow.com/a/1068308/13216
             var m = arg.match(/^--([^=]+)=([\s\S]*)$/);
-            setArg(m[1], m[2], arg);
+            var key = m[1];
+            var value = m[2];
+            if (flags.bools[key]) {
+                value = value !== 'false';
+            }
+            setArg(key, value, arg);
         }
         else if (/^--no-.+/.test(arg)) {
             var key = arg.match(/^--no-(.+)/)[1];

--- a/test/bool.js
+++ b/test/bool.js
@@ -117,3 +117,27 @@ test('boolean and --x=true', function(t) {
     t.same(parsed.other, 'false');
     t.end();
 });
+
+test('boolean --boool=true', function (t) {
+    var parsed = parse(['--boool=true'], {
+        default: {
+            boool: false
+        },
+        boolean: ['boool']
+    });
+
+    t.same(parsed.boool, true);
+    t.end();
+});
+
+test('boolean --boool=false', function (t) {
+    var parsed = parse(['--boool=false'], {
+        default: {
+          boool: true
+        },
+        boolean: ['boool']
+    });
+
+    t.same(parsed.boool, false);
+    t.end();
+});


### PR DESCRIPTION
When passing the boolean argument with `--boool=true` or `--boool=false`.

(Sorry about the space removing clutter. WebStorm does this automatically.)