### PR TITLE
Fix inconsistent handling of empty values

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ module.exports = function (args, opts) {
             
             var key = arg.slice(-1)[0];
             if (!broken && key !== '-') {
-                if (args[i+1] && !/^(-|--)[^-]/.test(args[i+1])
+                if (args[i+1] !== undefined && !/^(-|--)[^-]/.test(args[i+1])
                 && !flags.bools[key]
                 && (aliases[key] ? !flags.bools[aliases[key]] : true)) {
                     setArg(key, args[i+1], arg);

--- a/test/long.js
+++ b/test/long.js
@@ -27,5 +27,10 @@ test('long opts', function (t) {
         { host : 'localhost', port : 555, _ : [] },
         'long captures eq'
     );
+    t.deepEqual(
+        parse([ '--pow', '' ]),
+        { pow : '', _ : [] },
+        'long empty capture'
+    );
     t.end();
 });

--- a/test/short.js
+++ b/test/short.js
@@ -41,6 +41,11 @@ test('short', function (t) {
         { h : 'localhost', p : 555, _ : [] },
         'short captures'
     );
+    t.deepEqual(
+        parse([ '-h', '' ]),
+        { h : '', _ : [] },
+        'short empty capture'
+    );
     t.end();
 });
  


### PR DESCRIPTION
This patch allows empty values for short options so that

```js
['-h', '']
```

is parsed as

```js
{ _: [], h: '' }
```

Previously this worked for long options but empty-valued short options were treated as booleans (and `''` went to `_`).

Close #56.