### PR TITLE
Reorganize readme & include missing `--no` docs

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,6 @@
 # minimist
 
-parse argument options
+Parse argument options.
 
 This module is the guts of optimist's argument parser without all the
 fanciful decoration.
@@ -12,16 +12,17 @@ fanciful decoration.
 # example
 
 ``` js
+// example/parse.js
 var argv = require('minimist')(process.argv.slice(2));
 console.dir(argv);
 ```
 
-```
+```sh
 $ node example/parse.js -a beep -b boop
 { _: [], a: 'beep', b: 'boop' }
 ```
 
-```
+```sh
 $ node example/parse.js -x 3 -y 4 -n5 -abc --beep=boop foo bar baz
 { _: [ 'foo', 'bar', 'baz' ],
   x: 3,
@@ -43,40 +44,45 @@ var parseArgs = require('minimist')
 
 Return an argument object `argv` populated with the array arguments from `args`.
 
-`argv._` contains all the arguments that didn't have an option associated with
-them.
+**argv**
 
-Numeric-looking arguments will be returned as numbers unless `opts.string` or
-`opts.boolean` is set for that argument name.
+* `argv._` contains all the arguments that didn't have an option associated with
+  them.
+* Numeric-looking arguments will be returned as numbers unless `opts.string` or
+  `opts.boolean` is set for that argument name.
+* Any arguments after `'--'` will not be parsed and will end up in `argv._`.
+* Boolean flags starting with `--no` will be `false`.
+  - i.e. `--no-moo` will parse as `{ moo: false }` in `argv`.
 
-Any arguments after `'--'` will not be parsed and will end up in `argv._`.
-
-options can be:
+**opts**
 
 * `opts.string` - a string or array of strings argument names to always treat as
-strings
+  strings.
 * `opts.boolean` - a boolean, string or array of strings to always treat as
-booleans. if `true` will treat all double hyphenated arguments without equal signs
-as boolean (e.g. affects `--foo`, not `-f` or `--foo=bar`)
+  booleans. if `true` will treat all double hyphenated arguments without equal
+  signs as boolean
+  - e.g. affects `--foo`, not `-f` or `--foo=bar`.
 * `opts.alias` - an object mapping string names to strings or arrays of string
-argument names to use as aliases
-* `opts.default` - an object mapping string argument names to default values
+   argument names to use as aliases.
+* `opts.default` - an object mapping string argument names to default values.
 * `opts.stopEarly` - when true, populate `argv._` with everything after the
-first non-option
+  first non-option.
 * `opts['--']` - when true, populate `argv._` with everything before the `--`
-and `argv['--']` with everything after the `--`. Here's an example:
+  and `argv['--']` with everything after the `--`.
+  - Note that with `opts['--']` set, parsing for arguments still stops after
+    the `--`.
+  - Example:
+
+    ```js
+    > require('./')('one two three -- four five --six'.split(' '), { '--': true })
+    { _: [ 'one', 'two', 'three' ],
+      '--': [ 'four', 'five', '--six' ] }
+    ```
+
 * `opts.unknown` - a function which is invoked with a command line parameter not
-defined in the `opts` configuration object. If the function returns `false`, the
-unknown option is not added to `argv`.
+  defined in the `opts` configuration object. If the function returns `false`,
+  the unknown option is not added to `argv`.
 
-```
-> require('./')('one two three -- four five --six'.split(' '), { '--': true })
-{ _: [ 'one', 'two', 'three' ],
-  '--': [ 'four', 'five', '--six' ] }
-```
-
-Note that with `opts['--']` set, parsing for arguments still stops after the
-`--`.
 
 # install
 


### PR DESCRIPTION
Resolves issue #54

Other changes (from top to bottom):

* Consistent usage of periods in document
* Added a hint for the file name in the initial example
* Add code highlighting for the usage of the example script
* Clearly mark the `argv` vs. `options` sections of `parseArgs`
  documentation
* Use a list for the `argv` explanations similar to `opts` section
* Fixed the placement of `opts.unknown` option - it got a bit lost
  in the mix within the `argv['--']` option