### PR TITLE
fix boolean values with multiple aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,12 @@ module.exports = function (args, opts) {
         }
     }
     
+    function aliasIsBoolean(key) {
+      return aliases[key].some(function (x) {
+          return flags.bools[x];
+      });
+    }
+
     for (var i = 0; i < args.length; i++) {
         var arg = args[i];
         
@@ -110,7 +116,7 @@ module.exports = function (args, opts) {
             if (next !== undefined && !/^-/.test(next)
             && !flags.bools[key]
             && !flags.allBools
-            && (aliases[key] ? !flags.bools[aliases[key]] : true)) {
+            && (aliases[key] ? !aliasIsBoolean(key) : true)) {
                 setArg(key, next, arg);
                 i++;
             }
@@ -155,7 +161,7 @@ module.exports = function (args, opts) {
             if (!broken && key !== '-') {
                 if (args[i+1] && !/^(-|--)[^-]/.test(args[i+1])
                 && !flags.bools[key]
-                && (aliases[key] ? !flags.bools[aliases[key]] : true)) {
+                && (aliases[key] ? !aliasIsBoolean(key) : true)) {
                     setArg(key, args[i+1], arg);
                     i++;
                 }

--- a/test/bool.js
+++ b/test/bool.js
@@ -80,6 +80,29 @@ test('boolean and alias with options hash', function (t) {
     t.end();
 });
 
+test('boolean and alias array with options hash', function (t) {
+    var aliased = [ '-h', 'derp' ];
+    var regular = [ '--herp', 'derp' ];
+    var alt = [ '--harp', 'derp' ];
+    var opts = {
+        alias: { 'h': ['herp', 'harp'] },
+        boolean: 'h'
+    };
+    var aliasedArgv = parse(aliased, opts);
+    var propertyArgv = parse(regular, opts);
+    var altPropertyArgv = parse(alt, opts);
+    var expected = {
+        harp: true,
+        herp: true,
+        h: true,
+        '_': [ 'derp' ]
+    };
+    t.same(aliasedArgv, expected);
+    t.same(propertyArgv, expected);
+    t.same(altPropertyArgv, expected);
+    t.end();
+});
+
 test('boolean and alias using explicit true', function (t) {
     var aliased = [ '-h', 'true' ];
     var regular = [ '--herp',  'true' ];


### PR DESCRIPTION
When using a boolean value that has an array of aliases
the aliases show not swallow the next value but should
be treated like other booleans

```javascript
var regular = [ '--herp', 'derp' ];
var alt = [ '--harp', 'derp' ];
var opts = {
  alias: { 'h': ['herp', 'harp'] },
  boolean: 'h'
};

var argv = parse(regular, opts);
assert.strictEqual(argv.herp, true); // fails with 'derp'
assert.strictEqual(argv.harp, true); // fails with 'derp'
assert.strictEqual(argv._[0], 'derp'); // fails with undefined

var argvAlt = parse(alt, opts);
assert.strictEqual(argv.herp, true); // fails with 'derp'
assert.strictEqual(argv.harp, true); // fails with 'derp'
assert.strictEqual(argv._[0], 'derp'); // fails with undefined
```
