### PR TITLE
Fix inaccurate arg parsing for -<key>=<value> pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ module.exports = function (args, opts) {
                 }
                 
                 if (letters[j+1] && letters[j+1].match(/\W/)) {
-                    setArg(letters[j], arg.slice(j+2), arg);
+                    setArg(letters[j], arg.slice(j+3), arg);
                     broken = true;
                     break;
                 }


### PR DESCRIPTION
Found this bug while using minimist in http://github.com/maxogden/dat.

People were trying to input arguments this way:

```
$ node example/parse.js -a=beep -b=boop
{ _: [], a: '=beep', b: '=boop' }
```

Instead of the documented:
```
$ node example/parse.js -a beep -b boop
{ _: [], a: 'beep', b: 'boop' }
```

Seems like minimist should do something here. 

I've implemented basically the most simple fix, which is only counting values after the 3rd index in the argument string, so we'd see:

```
$ node example/parse.js -a=beep -b=boop
{ _: [], a: 'beep', b: 'boop' }
```

Another option for helping devs and users with this misconception could be not registering it at all, so

```
$ node example/parse.js -a=beep -b=boop
{ _: [] }
```

or only registering values after the space:

```
$ node example/parse.js -a=beep -b=boop
{ _: [], a: '', b: '' }
```

Thoughts?