### PR TITLE
Add smart aliasing for negated aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,7 +176,14 @@ module.exports = function (args, opts) {
                     i++;
                 }
                 else {
-                    setArg(key, flags.strings[key] ? '' : true, arg);
+                    var negated = false;
+                    (aliases[key] || []).forEach(function (x) {
+                        if( /^no-.+/.test(x) ) {
+                            key = x.match(/^no-(.+)/)[1];
+                            negated = true;
+                        }
+                    });
+                    setArg(key, flags.strings[key] ? '' : !negated, arg);
                 }
             }
         }


### PR DESCRIPTION
A naive solution to #55 . If the arg key has any aliases that are considered negations (start with `no-`) then update the key to its non-negated form and set the value to false. 