### PR TITLE
fix every arg to be string

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,11 @@ module.exports = function (args, opts) {
     
     var notFlags = [];
 
+    // Make sure to be a string
+    for (var i = 0; i < args.length; i++) {
+        args[i] += '';
+    }
+
     if (args.indexOf('--') !== -1) {
         notFlags = args.slice(args.indexOf('--')+1);
         args = args.slice(0, args.indexOf('--'));

--- a/test/bool.js
+++ b/test/bool.js
@@ -153,6 +153,18 @@ test('boolean --boool=true', function (t) {
     t.end();
 });
 
+test('boolean --boool, with real true', function (t) {
+    var parsed = parse(['--boool', true], {
+        default: {
+            boool: false
+        },
+        boolean: ['boool']
+    });
+
+    t.same(parsed.boool, true);
+    t.end();
+});
+
 test('boolean --boool=false', function (t) {
     var parsed = parse(['--boool=false'], {
         default: {

--- a/test/short.js
+++ b/test/short.js
@@ -17,6 +17,14 @@ test('short', function (t) {
         'short boolean'
     );
     t.deepEqual(
+        parse([ '-b', true ], {
+            alias:{ b: 'bar' },
+            boolean: ['bar']
+        }),
+        { b : true, bar: true, _ : [] },
+        'short with real true'
+    );
+    t.deepEqual(
         parse([ 'foo', 'bar', 'baz' ]),
         { _ : [ 'foo', 'bar', 'baz' ] },
         'bare'


### PR DESCRIPTION
```
> minimist(['--key', true], {boolean: ['key']})
{ _: [], key: false } // error!
```

Normally, `args` is an array of `string`. But if passed the result of `minimist` to another call of `minimist`, some errors will happen, as similar as the 2 added test cases.

The root cause is that `/true/.test(true)` returns `true`, but `true === 'true'` returns `false`. It appears 2 places in codes of `minimist`.