### PR TITLE
Keep `--` when using `stopEarly` parse option

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function (args, opts) {
     
     var notFlags = [];
 
-    if (args.indexOf('--') !== -1) {
+    if (!opts.stopEarly && args.indexOf('--') !== -1) {
         notFlags = args.slice(args.indexOf('--')+1);
         args = args.slice(0, args.indexOf('--'));
     }

--- a/test/stop_early.js
+++ b/test/stop_early.js
@@ -13,3 +13,15 @@ test('stops parsing on the first non-option when stopEarly is set', function (t)
 
     t.end();
 });
+
+test('includes -- with stop early', function (t) {
+    var argv = parse(['aaa', '--bbb', '--', 'ccc'], {
+        stopEarly: true
+    });
+
+    t.deepEqual(argv, {
+      _: ['aaa', '--bbb', '--', 'ccc']
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Fixes #71.