### PR TITLE
Making module init greener – saving trees.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = function (args, opts) {
     if (!opts) opts = {};
+    if (!args) args = process.argv.slice(2);
     
     var flags = { bools : {}, strings : {}, unknownFn: null };
 


### PR DESCRIPTION
Vast majority of minimist's uses starts with:

```
var argv = require('minimist')(process.argv.slice(2));
```

It's super cool that initialization can take something custom instead of `process.argv.slice(2)`, since it can help in testing etc., but the reality is: majority of live code always passes `process.argv.slice(2)` so process.argv.slice(2) seems like an **excellent** candidate for the default value, here? Especially considering how awkward it is and how much cleaner/nicer it would be to omit it, when the default is just fine. With this default, initialization is going to look like the following:

```
var argv = require('minimist')();
```
