### PR TITLE
Do not parse numbers that evaluate to Infinity

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,6 +231,7 @@ function hasKey (obj, keys) {
 function isNumber (x) {
     if (typeof x === 'number') return true;
     if (/^0x[0-9a-f]+$/i.test(x)) return true;
-    return /^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(x);
+    return /^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(x) &&
+      Number(x) !== Infinity;
 }
 

--- a/test/num.js
+++ b/test/num.js
@@ -34,3 +34,18 @@ test('already a number', function (t) {
     t.deepEqual(typeof argv._[0], 'number');
     t.end();
 });
+
+test('scientific notation infinity', function (t) {
+    // These numbers evaluate to Infinity
+    var argv = parse([
+        '-x', '87e3202',
+        '87e3202'
+    ]);
+    t.deepEqual(argv, {
+        x : '87e3202',
+        _ : [ '87e3202' ]
+    });
+    t.deepEqual(typeof argv.x, 'string');
+    t.deepEqual(typeof argv._[0], 'string');
+    t.end();
+});


### PR DESCRIPTION
Some numbers, like `87e3202`, are recognised as numbers by the
`isNumber` utility, which results on minimist parsing them by default
and thus passing a meaningless `Infinity` value to the user.

Since parsing scientific notation numbers are supported on minimist as a
feature, the approach of this patch is to only return `true` from
`isNumber` if the string indeed represents a number, but it doesn't
resolve to `Infinity` when being parsed as such, therefore not breaking
any existing functionality on the module.

The use case where this bug showed up was passing (shorter) UUIDs as
command line arguments.