### PR TITLE
include only `index.js` in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.0",
   "description": "parse argument options",
   "main": "index.js",
+  "files": ["index.js"],
   "devDependencies": {
     "covert": "^1.0.0",
     "tap": "~0.4.0",


### PR DESCRIPTION
```
$ tree node_modules/minimist -I node_modules

node_modules/minimist
├── example/
│   └── parse.js
├── test/
│   ├── all_bool.js
│   ├── bool.js
│   ├── dash.js
│   ├── default_bool.js
│   ├── dotted.js
│   ├── kv_short.js
│   ├── long.js
│   ├── num.js
│   ├── parse.js
│   ├── parse_modified.js
│   ├── short.js
│   ├── stop_early.js
│   ├── unknown.js
│   └── whitespace.js
├── .travis.yml
├── LICENSE
├── index.js
├── package.json
└── readme.markdown
```
​​​
Loading unnecessary files is one of the reasons `npm install`s take so darn long. Anton Rudeshko very well put it in [his article](http://www.rudeshko.com/web/2014/05/13/help-people-consume-your-npm-packages.html):

> Speaking in terms of object-oriented design, your npm package should be [highly cohesive](https://en.wikipedia.org/wiki/Cohesion_(computer_science)) and [loosely coupled](https://en.wikipedia.org/wiki/Loose_coupling). Your package should do only one thing and do it well.

Corey Butler also wrote [a nice article](https://medium.com/@goldglovecb/npm-needs-a-personal-trainer-537e0f8859c6) about why it's important to minimize module footprints, including test suite:

> In the rare situation a developer actually wants to run your test suite on their own local computer, they'll likely clone or fork it.

Also see [NPM docs](https://docs.npmjs.com/files/package.json#files) for details about `files` field in `package.json`.