### PR TITLE
optimizing logical expression on line 149

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,8 +146,8 @@ module.exports = function (args, opts) {
                     break;
                 }
                 
-                if (/[A-Za-z]/.test(letters[j])
-                && /-?\d+(\.\d*)?(e-?\d+)?$/.test(next)) {
+                if (/-?\d+(\.\d*)?(e-?\d+)?$/.test(next) &&
+                    /[A-Za-z]/.test(letters[j])) {
                     setArg(letters[j], next, arg);
                     broken = true;
                     break;


### PR DESCRIPTION
You might consider optimizing the logical expression on line 149 by changing the order in which _test_ methods are executed. By running all unit tests, I observed that the _/[A-Za-z]/.test(letters[j])_ call is false for most of cases. By swapping the order of methods, I obtained the performance improvement of 12.8% on V8 engine for test 

> mixed short bool and capture 
This simple change doesn't degrade the performance of other tests, and it doesn't affect the readability of the code.