### PR TITLE
Add files whitelist to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "tap": "~0.4.0",
     "tape": "^3.5.0"
   },
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "tap test/*.js",
     "coverage": "covert test/*.js"


### PR DESCRIPTION
This excludes `examples/`, `test/` and `.travis.yml` from the npm package.

No biggy per install (~18 KB of files) but the 3.6 KB smaller packaged `.tgz` would save the npm registry about 93 GB a month with minimist's download numbers :open_mouth:

This change would close #84 