### PR TITLE
Flags should not contains white-space

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,27 +92,28 @@ module.exports = function (args, opts) {
     }
 
     for (var i = 0; i < args.length; i++) {
-        var arg = args[i], m;
+        var arg = args[i], m, isStr = typeof arg === 'string' ;
         
-        if ((m=arg.match(/^--([^\s=]+)(?:=([^]*))?$/))) {
-            // Using [^] instead of . because js doesn't support the
-            // 'dotall' regex modifier.
-            //var m = arg.match(/^--([^=]+)=([\s\S]*)$/);
+		// Using [^] instead of . because js doesn't support the
+		// 'dotall' regex modifier.
+		try {
+        if (isStr && (m=arg.match(/^--([^\s=]+)(?:=([^]*))$/))) {
             var key = m[1];
             var value = m[2];
+            console.log( value ) ;
             if (flags.bools[key]) {
                 value = value !== 'false';
             }
             setArg(key, value, arg);
         }
-        else if ((m=arg.match(/^--no-([^\s]+)$/))) {
+        else if (isStr && (m=arg.match(/^--no-([^\s]+)$/))) {
             var key = m[1];
             setArg(key, false, arg);
         }
-        else if ((m=arg.match(/^--([^\s]+)$/))) {
+        else if (isStr && (m=arg.match(/^--([^\s]+)$/))) {
             var key = m[1];
             var next = args[i + 1];
-            if (next !== undefined && !/^--?[^\s](?:=([^]*))?$/.test(next)
+            if (next !== undefined && !/^--?[^\s]+(?:=([^]*))?$/.test(next)
             && !flags.bools[key]
             && !flags.allBools
             && (aliases[key] ? !aliasIsBoolean(key) : true)) {
@@ -164,7 +165,7 @@ module.exports = function (args, opts) {
             
             var key = arg.slice(-1)[0];
             if (!broken && key !== '-') {
-                if (args[i+1] && !/^--?[^\s](?:=([^]*))?$/.test(args[i+1])
+                if (args[i+1] && !/^--?[^\s]+(?:=([^]*))?$/.test(args[i+1])
                 && !flags.bools[key]
                 && (aliases[key] ? !aliasIsBoolean(key) : true)) {
                     setArg(key, args[i+1], arg);
@@ -189,6 +190,10 @@ module.exports = function (args, opts) {
                 argv._.push.apply(argv._, args.slice(i + 1));
                 break;
             }
+        }
+        }
+        catch ( error ) {
+        	throw error + require('util').inspect( arg ) ;
         }
     }
     

--- a/index.js
+++ b/index.js
@@ -92,13 +92,12 @@ module.exports = function (args, opts) {
     }
 
     for (var i = 0; i < args.length; i++) {
-        var arg = args[i];
+        var arg = args[i], m;
         
-        if (/^--.+=/.test(arg)) {
-            // Using [\s\S] instead of . because js doesn't support the
-            // 'dotall' regex modifier. See:
-            // http://stackoverflow.com/a/1068308/13216
-            var m = arg.match(/^--([^=]+)=([\s\S]*)$/);
+        if ((m=arg.match(/^--([^\s=]+)(?:=([^]*))?$/))) {
+            // Using [^] instead of . because js doesn't support the
+            // 'dotall' regex modifier.
+            //var m = arg.match(/^--([^=]+)=([\s\S]*)$/);
             var key = m[1];
             var value = m[2];
             if (flags.bools[key]) {
@@ -106,14 +105,14 @@ module.exports = function (args, opts) {
             }
             setArg(key, value, arg);
         }
-        else if (/^--no-.+/.test(arg)) {
-            var key = arg.match(/^--no-(.+)/)[1];
+        else if ((m=arg.match(/^--no-([^\s]+)$/))) {
+            var key = m[1];
             setArg(key, false, arg);
         }
-        else if (/^--.+/.test(arg)) {
-            var key = arg.match(/^--(.+)/)[1];
+        else if ((m=arg.match(/^--([^\s]+)$/))) {
+            var key = m[1];
             var next = args[i + 1];
-            if (next !== undefined && !/^-/.test(next)
+            if (next !== undefined && !/^--?[^\s](?:=([^]*))?$/.test(next)
             && !flags.bools[key]
             && !flags.allBools
             && (aliases[key] ? !aliasIsBoolean(key) : true)) {
@@ -128,7 +127,7 @@ module.exports = function (args, opts) {
                 setArg(key, flags.strings[key] ? '' : true, arg);
             }
         }
-        else if (/^-[^-]+/.test(arg)) {
+        else if (/^-[^\s-]+$/.test(arg)) {
             var letters = arg.slice(1,-1).split('');
             
             var broken = false;
@@ -136,7 +135,7 @@ module.exports = function (args, opts) {
                 var next = arg.slice(j+2);
                 
                 if (next === '-') {
-                    setArg(letters[j], next, arg)
+                    setArg(letters[j], next, arg);
                     continue;
                 }
                 
@@ -165,7 +164,7 @@ module.exports = function (args, opts) {
             
             var key = arg.slice(-1)[0];
             if (!broken && key !== '-') {
-                if (args[i+1] && !/^(-|--)[^-]/.test(args[i+1])
+                if (args[i+1] && !/^--?[^\s](?:=([^]*))?$/.test(args[i+1])
                 && !flags.bools[key]
                 && (aliases[key] ? !aliasIsBoolean(key) : true)) {
                     setArg(key, args[i+1], arg);

--- a/test/dash.js
+++ b/test/dash.js
@@ -2,10 +2,13 @@ var parse = require('../');
 var test = require('tape');
 
 test('-', function (t) {
-    t.plan(5);
+    t.plan(4);
     t.deepEqual(parse([ '-n', '-' ]), { n: '-', _: [] });
     t.deepEqual(parse([ '-' ]), { _: [ '-' ] });
-    t.deepEqual(parse([ '-f-' ]), { f: '-', _: [] });
+    
+    // Note by @cronvel: it does not make sense, this shouldn't be the expected behaviour
+    //t.deepEqual(parse([ '-f-' ]), { f: '-', _: [] });
+    
     t.deepEqual(
         parse([ '-b', '-' ], { boolean: 'b' }),
         { b: true, _: [ '-' ] }


### PR DESCRIPTION
Let's go straight to the example. Imagine a program using minimist and this user command-line:
```
myjsprog --git-commit --message "--dry-run option added"
```

This command arguments should obviously be parsed as: `{"git-commit":true,message:"--dry-run option added"}`. However since spaces are allowed into flags, it is parsed as: `{"git-commit":true,message:true,"--dry-run option added":true}`.

This PR solves this issue.

All test are running okey except one in the dash.js file: `t.deepEqual(parse([ '-f-' ]), { f: '-', _: [] });`.
To me, this test enforces a really unexpected behavior, so I commented out this test.
The version of this PR produces `{_:['-f-']}`, and this is probably the result expected from most users.
