### PR TITLE
Add `requireEquals` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = function (args, opts) {
     if (!opts) opts = {};
     
-    var flags = { bools : {}, strings : {}, unknownFn: null };
+    var flags = { bools : {}, strings : {}, unknownFn: null, requireEquals: opts.requireEquals };
 
     if (typeof opts['unknown'] === 'function') {
         flags.unknownFn = opts['unknown'];
@@ -113,7 +113,9 @@ module.exports = function (args, opts) {
         else if (/^--.+/.test(arg)) {
             var key = arg.match(/^--(.+)/)[1];
             var next = args[i + 1];
-            if (next !== undefined && !/^-/.test(next)
+            if (flags.requireEquals) {
+                setArg(key, flags.strings[key] ? '' : true, arg);
+            } else if (next !== undefined && !/^-/.test(next)
             && !flags.bools[key]
             && !flags.allBools
             && (aliases[key] ? !aliasIsBoolean(key) : true)) {

--- a/readme.markdown
+++ b/readme.markdown
@@ -63,6 +63,12 @@ argument names to use as aliases
 * `opts.default` - an object mapping string argument names to default values
 * `opts.stopEarly` - when true, populate `argv._` with everything after the
 first non-option
+* `opts.requireEquals` - when true double hyphenated arguments can only be given
+a value by specifying the value after a `=`. This allows double hyphenated
+arguments to be followed by, for example, pathnames without the pathname being
+treated as a value for the preceding double hyphenated argument. E.g., when set
+`--foo=abc` is argument `foo` with value `abc`, but `--foo abc` is argument `foo`
+with a separate `argv._` element containing `abc`.
 * `opts['--']` - when true, populate `argv._` with everything before the `--`
 and `argv['--']` with everything after the `--`. Here's an example:
 

--- a/test/long.js
+++ b/test/long.js
@@ -18,6 +18,11 @@ test('long opts', function (t) {
         'long capture eq'
     );
     t.deepEqual(
+        parse([ '--pow', 'xixxle' ], {requireEquals: true}),
+        { pow : true, _ : ['xixxle'] },
+        'long capture requireEquals'
+    );
+    t.deepEqual(
         parse([ '--host', 'localhost', '--port', '555' ]),
         { host : 'localhost', port : 555, _ : [] },
         'long captures sp'


### PR DESCRIPTION
If you require an option like `--foo` and you need to allow it to be specified both with and without a string value, you need the change in this pull request. You can then use `--foo x.js` to specify `--foo` as a parameter, which will be returned as a `boolean` with value `true`, and also `x.js` will be added to the `_` array as a non-option argument. In other words, if the `requireEquals` option is set your arguments in this example won't be interpreted the same as `--foo=x.js`.
