### PR TITLE
Accept  opts.strings=true  to never convert option values to numbers (fixes #36)

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ module.exports = function (args, opts) {
           flags.bools[key] = true;
       });
     }
+
+    if (typeof opts['strings'] === 'boolean' && opts['strings']) {
+        flags.allStrings = true;
+    }
     
     var aliases = {};
     Object.keys(opts.alias || {}).forEach(function (key) {
@@ -56,7 +60,7 @@ module.exports = function (args, opts) {
             if (flags.unknownFn(arg) === false) return;
         }
 
-        var value = !flags.strings[key] && isNumber(val)
+        var value = !flags.allStrings && !flags.strings[key] && isNumber(val)
             ? Number(val) : val
         ;
         setKey(argv, key.split('.'), value);

--- a/readme.markdown
+++ b/readme.markdown
@@ -53,8 +53,9 @@ Any arguments after `'--'` will not be parsed and will end up in `argv._`.
 
 options can be:
 
-* `opts.string` - a string or array of strings argument names to always treat as
-strings
+* `opts.string` - a string or array of strings of argument names whose values to
+always treat as strings. if `true` will treat all argument values as strings
+regardless of name.
 * `opts.boolean` - a boolean, string or array of strings to always treat as
 booleans. if `true` will treat all double hyphenated arguments without equal signs
 as boolean (e.g. affects `--foo`, not `-f` or `--foo=bar`)


### PR DESCRIPTION
Sometimes it's useful to never convert values that happen to look like numbers, into numbers. The `opts.strings` option used to accept just a fixed set of argument names.

This PR extends the logic similar to the `opts.boolean` option, accepting the `true` value to ask to never convert any argument's value regardless of name.

(see also #36)