### PR TITLE
Allow positional arguments to be treated as string

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,16 @@ module.exports = function (args, opts) {
         });
     });
 
-    [].concat(opts.string).filter(Boolean).forEach(function (key) {
-        flags.strings[key] = true;
-        if (aliases[key]) {
-            flags.strings[aliases[key]] = true;
-        }
-     });
+    [].concat(opts.string)
+        .filter(function (val) {
+            return Boolean(val) || val === 0;
+        })
+        .forEach(function (key) {
+            flags.strings[key] = true;
+            if (aliases[key]) {
+                flags.strings[aliases[key]] = true;
+            }
+         });
 
     var defaults = opts['default'] || {};
     
@@ -182,9 +186,8 @@ module.exports = function (args, opts) {
         }
         else {
             if (!flags.unknownFn || flags.unknownFn(arg) !== false) {
-                argv._.push(
-                    flags.strings['_'] || !isNumber(arg) ? arg : Number(arg)
-                );
+                var asString = flags.strings[i] || flags.strings['_'] || !isNumber(arg);
+                argv._.push(asString ? arg : Number(arg));
             }
             if (opts.stopEarly) {
                 argv._.push.apply(argv._, args.slice(i + 1));

--- a/readme.markdown
+++ b/readme.markdown
@@ -53,8 +53,8 @@ Any arguments after `'--'` will not be parsed and will end up in `argv._`.
 
 options can be:
 
-* `opts.string` - a string or array of strings argument names to always treat as
-strings
+* `opts.string` - a string or array of strings argument names (or indexes of
+positional arguments) to always treat as strings
 * `opts.boolean` - a boolean, string or array of strings to always treat as
 booleans. if `true` will treat all double hyphenated arguments without equal signs
 as boolean (e.g. affects `--foo`, not `-f` or `--foo=bar`)

--- a/test/num.js
+++ b/test/num.js
@@ -8,7 +8,8 @@ test('nums', function (t) {
         '-z', '1e7',
         '-w', '10f',
         '--hex', '0xdeadbeef',
-        '789'
+        '789',
+        '123f'
     ]);
     t.deepEqual(argv, {
         x : 1234,
@@ -16,7 +17,7 @@ test('nums', function (t) {
         z : 1e7,
         w : '10f',
         hex : 0xdeadbeef,
-        _ : [ 789 ]
+        _ : [ 789, '123f' ]
     });
     t.deepEqual(typeof argv.x, 'number');
     t.deepEqual(typeof argv.y, 'number');

--- a/test/parse.js
+++ b/test/parse.js
@@ -97,6 +97,10 @@ test('stringArgs', function (t) {
     t.same(s[0], '  ');
     t.same(typeof s[1], 'string');
     t.same(s[1], '  ');
+
+    s = parse(['11', '22', '33'], {string: [0, 2]})._;
+    t.deepEqual(s, ['11', 22, '33'])
+    
     t.end();
 });
 


### PR DESCRIPTION
This PR adds the ability to pass positional argument indexes to `opts.string`, e.g.
```
> require('./')('1 2 3'.split(' '), { string: [0, 2] })
{ _: [ '1', 2, '3'] }
```

it also works in combination with argument names, e.g.
```
> require('./')('1 2 3 --option=100'.split(' '), { string: [0, 2, 'option'] })
{ _: [ '1', 2, '3' ], option: '100' }
```