### PR TITLE
Add test for describing how the multiple boolean arguments are handled

### DIFF
--- a/test/no-bool.js
+++ b/test/no-bool.js
@@ -1,0 +1,44 @@
+var parse = require('../');
+var test = require('tape');
+
+test('boolean with its negation', function (t) {
+    var argv = parse(['--moo', '--no-moo'], {
+        boolean: ['moo']
+    });
+
+    t.deepEqual(argv, {
+        moo: false,
+        _: []
+    });
+
+    t.deepEqual(typeof argv.moo, 'boolean');
+    t.end();
+});
+
+test('boolean negation with its affermative', function (t) {
+    var argv = parse(['--no-moo', '--moo'], {
+        boolean: ['moo']
+    });
+
+    t.deepEqual(argv, {
+        moo: true,
+        _: []
+    });
+
+    t.deepEqual(typeof argv.moo, 'boolean');
+    t.end();
+});
+
+test('boolean negation with its affermative with the negation again', function (t) {
+    var argv = parse(['--no-moo', '--moo', '--no-moo'], {
+        boolean: ['moo']
+    });
+
+    t.deepEqual(argv, {
+        moo: false,
+        _: []
+    });
+
+    t.deepEqual(typeof argv.moo, 'boolean');
+    t.end();
+});


### PR DESCRIPTION
This PR adds test in order to track the behaviour adopted on multiple boolean arguments like

```
./my-script --no-moo --moo
```

I'm not sure if the current implementation is ok but at least it is tracked. Particularly [this](https://github.com/allevo/minimist/blob/1e25bd2876c5961282fd3a43c6937fb8b699d70d/test/no-bool.js#L24)