### PR TITLE
remove test/ from published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test/
+.travis.yml


### PR DESCRIPTION
while looking at installed package sizes i was surprised to see 72K in the test directory for minimist.

this makes the distributed package 72K smaller; not a big deal but distributing the tests in the production package didn't seem to be necessary.