### PR TITLE
[CVE-2021-44906] 🔒️ fixed Prototype Pollution 

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,10 +67,14 @@ module.exports = function (args, opts) {
     }
 
     function setKey (obj, keys, value) {
+      var isConstructorOrProto = (_obj, _key) =>
+        (_key === 'constructor' && typeof _obj[_key] === 'function') ||
+        _key === '__proto__';
+
         var o = obj;
         for (var i = 0; i < keys.length-1; i++) {
             var key = keys[i];
-            if (key === '__proto__') return;
+            if (isConstructorOrProto(obj, key)) return;
             if (o[key] === undefined) o[key] = {};
             if (o[key] === Object.prototype || o[key] === Number.prototype
                 || o[key] === String.prototype) o[key] = {};
@@ -79,7 +83,7 @@ module.exports = function (args, opts) {
         }
 
         var key = keys[keys.length - 1];
-        if (key === '__proto__') return;
+        if (isConstructorOrProto(obj, key)) return;
         if (o === Object.prototype || o === Number.prototype
             || o === String.prototype) o = {};
         if (o === Array.prototype) o = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minimist",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "parse argument options",
   "main": "index.js",
   "devDependencies": {

--- a/readme.markdown
+++ b/readme.markdown
@@ -30,7 +30,15 @@ $ node example/parse.js -x 3 -y 4 -n5 -abc --beep=boop foo bar baz
 ```
 
 # security
+## [Update 2022-03-21]
+*prototype pollution bug (CVE-2021-44906)*
+https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795
 
+All previous versions including 1.2.5 are still affected by a prototype pollution bug. Which just partially were closed since version 1.2.3.
+
+Version 1.2.6 resolves this issue.
+
+## Previous partial fix
 Previous versions had a prototype pollution bug that could cause privilege
 escalation in some circumstances when handling untrusted user input.
 

--- a/test/proto.js
+++ b/test/proto.js
@@ -42,3 +42,19 @@ test('proto pollution (constructor)', function (t) {
     t.equal(argv.y, undefined);
     t.end();
 });
+
+test('proto pollution (constructor function)', function (t) {
+    var argv = parse(['--_.concat.constructor.prototype.y', '123']);
+    function fnToBeTested() {}
+    t.equal(fnToBeTested.y, undefined);
+    t.equal(argv.y, undefined);
+    t.end();
+  });
+
+  // powered by snyk - https://github.com/backstage/backstage/issues/10343
+  test('proto pollution (constructor function) snyk', function (t) {
+    var argv = parse('--_.constructor.constructor.prototype.foo bar'.split(' '));
+    t.equal((function(){}).foo, undefined);
+    t.equal(argv.y, undefined);
+    t.end();
+  });


### PR DESCRIPTION
[insufficient fix for prototype pollution in setKey() CVE-2021-44906](https://github.com/substack/minimist/issues/164)
* added tests
* fixed CVE-2021-44906 

ref: https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795
ref: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44906